### PR TITLE
修复在https环境下不能正常显示问题

### DIFF
--- a/template.html
+++ b/template.html
@@ -1,5 +1,5 @@
 <div id="<%- id %>" style="width: <%- width %>;height: <%- height %>px;margin: 0 auto"></div>
-<script src="//cdn.bootcss.com/echarts/3.8.0/echarts.common.min.js"></script>
+<script src="https://cdn.bootcss.com/echarts/3.8.0/echarts.common.min.js"></script>
 <script type="text/javascript">
         // 基于准备好的dom，初始化echarts实例
         var myChart = echarts.init(document.getElementById('<%- id %>'));

--- a/template.html
+++ b/template.html
@@ -1,6 +1,5 @@
 <div id="<%- id %>" style="width: <%- width %>;height: <%- height %>px;margin: 0 auto"></div>
-<script src="http://echarts.baidu.com/dist/echarts.common.min.js"></script>
-
+<script src="//cdn.bootcss.com/echarts/3.8.0/echarts.common.min.js"></script>
 <script type="text/javascript">
         // 基于准备好的dom，初始化echarts实例
         var myChart = echarts.init(document.getElementById('<%- id %>'));


### PR DESCRIPTION
模板js的地址我换成了https://cdn.bootcss.com/echarts/3.8.0/echarts.common.min.js

在https环境下不能加载http的资源
但是在http环境下是可以加载https资源的,
所以换上了目前echarts最新版的3.8版本
解决该插件在https环境下不能正常显示的问题